### PR TITLE
Data generation fixes and information on necessary parameters for training and generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,13 @@ cd fairseq
 python train.py data-bin/eli5 --task translation --source-lang qd_source_bpe --target-lang qd_target_bpe --arch transformer_wmt_en_de_big_t2t --share-decoder-input-output-embed --dropout 1e-1 --attention-dropout 1e-1 --relu-dropout 1e-1 --criterion label_smoothed_cross_entropy --label-smoothing 1e-1 --optimizer adam --adam-betas '(0.9, 0.98)' --lr 1e-4 --lr-scheduler inverse_sqrt --warmup-updates 4000 --warmup-init-lr 1e-7 --min-lr 1e-9 --clip-norm 0 --no-progress-bar --log-interval 100
 ```
 
+Depending on the model you might need to increase the values for `--max-source-positions` and `--max-target-positions` (e.g., to 4096), and set `--max-tokens` and `--update-freq` to a suitable value.
+
 To generate from the model:
 ```
 cd fairseq
 PATH_TO_CHECKPOINT=model_checkpoint.pt
-python generate.py data-bin/eli5 --path $PATH_TO_CHECKPOINT --gen-subset valid --task translation --nbest 1 --source-lang qd_source_bpe --target-lang qd_target_bpe --beam 5 --batch-size 32 --remove-bpe --no-repeat-ngram-size 3 --max-len-b 500 --min-len 200
+python generate.py data-bin/eli5 --path $PATH_TO_CHECKPOINT --gen-subset valid --task translation --nbest 1 --source-lang qd_source_bpe --target-lang qd_target_bpe --beam 5 --batch-size 32 --remove-bpe --no-repeat-ngram-size 3 --max-len-b 500 --min-len 200 --max-source-positions 4096 --max-target-positions 4096 --skip-invalid-size-inputs-valid-test --model-overrides "{'max_source_positions':4096, 'max_target_positions':4096}"
 ```
 to evaluate on the test set, set:
 ```

--- a/model_code/process_data_to_source_target.py
+++ b/model_code/process_data_to_source_target.py
@@ -127,16 +127,16 @@ def masking_tokens(document):
     return source, target
 
 if __name__ == "__main__":
-	train_q, train_a, train_d = read_data(args.input + "/train_data.json")
+	train_q, train_a, train_d = read_data(args.input + "/explainlikeimfive_train.json")
 	form_source_target(train_q, train_d, train_a, args.output, "train")
-	valid_q, valid_a, valid_d = read_data(args.input + "/valid_data.json")
+	valid_q, valid_a, valid_d = read_data(args.input + "/explainlikeimfive_valid.json")
 	form_source_target(valid_q, valid_d, valid_a, args.output, "valid")
-	test_q, test_a, test_d = read_data(args.input + "/test_data.json")
+	test_q, test_a, test_d = read_data(args.input + "/explainlikeimfive_test.json")
 	form_source_target(test_q, test_d, test_a, args.output, "test")
 
-	train_q, train_a, train_d = read_data(args.input + "/train_data.json")
+	train_q, train_a, train_d = read_data(args.input + "/explainlikeimfive_train.json")
 	form_multitask_source_target(train_q, train_d, train_a, args.output, "train")
-	valid_q, valid_a, valid_d = read_data(args.input + "/valid_data.json")
+	valid_q, valid_a, valid_d = read_data(args.input + "/explainlikeimfive_valid.json")
 	form_multitask_source_target(valid_q, valid_d, valid_a, args.output, "valid", True)
-	test_q, test_a, test_d = read_data(args.input + "/test_data.json")
+	test_q, test_a, test_d = read_data(args.input + "/explainlikeimfive_test.json")
 	form_multitask_source_target(test_q, test_d, test_a, args.output, "test", True)

--- a/model_code/process_data_to_source_target.py
+++ b/model_code/process_data_to_source_target.py
@@ -20,7 +20,7 @@ def read_data(json_input):
     questions = []
     answers = []
     supports = []
-    for d in data[1::2]:
+    for d in data:
         questions.append(d["question"].strip())
         answers.append(d["answer"].strip())
         supports.append(d["document"].strip())


### PR DESCRIPTION
**Patch description**
During data creation and model training (Q-to-A) I've come across some obstacles (which I also described in #10). Many of them have been fixed meanwhile, and the rest is addressed in this pull request:

 * Every second example is skipped in process_data_to_source_target.py
 * The input file names in process_data_to_source_target.py do not match the ones from data_creation/finalize_qda.py
 * The readme does not contain information on max-target-positions etc. which are necessary to run the generation script. For instance, running the generation.py without max source and target positions skips 9893 examples from the validation split (which is almost all of them)

**Testing steps**
For the readme try to run the old commands without adaptation. For instance, generation without setting --max-source-positions 4096 --max-target-positions 4096 will skip almost all examples (see log below).

**Logs**
```
| WARNING: 9893 samples have invalid sizes and will be skipped, max_positions=(1024, 1024), first few sample ids=[9052, 6593, 4710, 9081, 8042, 5242, 890, 7521, 7079, 3455]
```

**Other information**
